### PR TITLE
Sourcing bashrc in docker-foam-extend-4.1

### DIFF
--- a/installation/installWithDocker.md
+++ b/installation/installWithDocker.md
@@ -64,7 +64,11 @@ and subsequently connect to it with
 ---
 ## Using solids4foam Within the Container
 
-Once you have logged into the container, you can navigate to the solids4foam tutorials directory with
+Once you have logged into the container, you need to source the `bashrc` file first.
+```
+. OpenFOAM/etc/bashrc
+```
+Then, you can navigate to the solids4foam tutorials directory with
 ```
 > cd $WM_PROJECT_DIR/../solids4foam/tutorials
 ```


### PR DESCRIPTION
To use the container `solids4foam/solids4foam-v2.0-foam-extend-4.1` one needs to source `bashrc` before `cd $WM_PROJECT_DIR/../solids4foam/tutorials`. Also there are two problems when it comes to using this container: 

1- As the `root` user, you get the following error when you run `blockMesh` for the cavity case:
```shell
--> FOAM FATAL IO ERROR: 
This code should not be executed by someone with administrator rights due to security reasons.
(it writes a shared library which then gets loaded using dlopen)
```
2- As the `dockeruser`, the error changes to
```shell
--> FOAM FATAL IO ERROR: 
Loading a shared library using case-supplied code is not enabled by default
because of security issues. If you trust the code you can enable this
facility be adding to the InfoSwitches setting in the system controlDict:

    allowSystemOperations 1

The system controlDict is either

    ~/.OpenFOAM/$WM_PROJECT_VERSION/controlDict

or

    $WM_PROJECT_DIR/etc/controlDict
```