### PR TITLE
bashrc path updated on foam-extend-4.1

### DIFF
--- a/installation/installWithDocker.md
+++ b/installation/installWithDocker.md
@@ -66,9 +66,9 @@ and subsequently, connect to it with
 
 Once you have logged into the container, you should load OpenFOAM using the appropriate command the version you downloaded:
 ```bash
-> source /usr/lib/openfoam/openfoam2012/etc/bashrc           # OpenFOAM-v2012
-> source /opt/openfoam9/etc/bashrc                           # OpenFOAM-9
-> source /home/openfoam/OpenFOAM/foam-extend-4.1/etc/bashrc  # foam-extend-4.1
+> source /usr/lib/openfoam/openfoam2012/etc/bashrc             # OpenFOAM-v2012
+> source /opt/openfoam9/etc/bashrc                             # OpenFOAM-9
+> source /home/dockeruser/OpenFOAM/foam-extend-4.1/etc/bashrc  # foam-extend-4.1
 ```
 You can then navigate to the solids4foam tutorials directory with
 ```

--- a/support/training-material.md
+++ b/support/training-material.md
@@ -10,25 +10,25 @@ Find a selection of trainings and presentations related to solids4foam below.
 
 ## Solid mechanics and fluid-solid interactions using solids4foam-v2.0
 
-[<img src="https://youtu.be/nhgn2mbG--A/default.jpg" alt="alt_text" width="60%">](https://youtu.be/nhgn2mbG--A)
+[<img src="http://img.youtube.com/vi/nhgn2mbG--A/maxresdefault.jpg" alt="alt_text" width="60%">](https://youtu.be/nhgn2mbG--A)
 <br>
 [**Slides**](https://www.researchgate.net/publication/372289192_Solid_mechanics_and_fluid-solid_interactions_using_solids4foam-v20): *2023, 18th OpenFOAM Workshop, Genoa, Italy. Speaker: Philip Cardiff*
 
 ## Solid mechanics and fluid-solid interactions using solids4foam 
 
-[<img src="https://youtu.be/UF3BZhL5A4E/default.jpg" alt="alt_text" width="60%">](https://youtu.be/UF3BZhL5A4E)
+[<img src="http://img.youtube.com/vi/UF3BZhL5A4E/maxresdefault.jpg" alt="alt_text" width="60%">](https://youtu.be/UF3BZhL5A4E)
 <br>
 [**Slides**](https://www.researchgate.net/publication/362289386_solids4foam_Overview_Demonstration_Cases): *2022, 17th OpenFOAM Workshop, Cambridge, UK. Speaker: Philip Cardiff*
 
 ## Solids4foam training
 
-[<img src="https://youtu.be/uKSQp2dQnGI/default.jpg" alt="alt_text" width="60%">](https://youtu.be/uKSQp2dQnGI)
+[<img src="http://img.youtube.com/vi/uKSQp2dQnGI/maxresdefault.jpg" alt="alt_text" width="60%">](https://youtu.be/uKSQp2dQnGI)
 <br>
 [**Slides**](https://www.researchgate.net/publication/373197329_Solid_mechanics_and_fluid-solid_interaction_using_the_solids4foam_toolbox?_sg=Q9hKcWClfLiZAYEAX8HDPeLiEUjMqH8vWQgG4uWiPTfPGdTYFQPsgR_-2mkGFZQFPuUG2lqHtsgdjaLB3CwJn4y7jJ2EKS16cSi7odu8.lZwQLR0F8P8iNwEN6gqtoTX2APNWhoIXpt_qLJO8OlBslEaaBU-G1eiLPQ_UwHvq_Aegm5rX_h8eJh4Rx7vW3g&_tp=eyJjb250ZXh0Ijp7InBhZ2UiOiJfZGlyZWN0In19): *2021, 3rd UCL OpenFOAM Workshop, London, UK. Speaker: Philip Cardiff*
 
 ## Finite volume method for solid mechanics
 
-[<img src="https://youtu.be/Y9Jju-oO_9Q/default.jpg" alt="alt_text" width="60%">](https://youtu.be/Y9Jju-oO_9Q)
+[<img src="http://img.youtube.com/vi/Y9Jju-oO_9Q/maxresdefault.jpg" alt="alt_text" width="60%">](https://youtu.be/Y9Jju-oO_9Q)
 <br>
 [**Slides**](https://www.researchgate.net/publication/373197086_The_finite_volume_method_for_solid_mechanics): *2021, 3rd UCL OpenFOAM Workshop, London, UK. Speaker: Philip Cardiff*
 

--- a/support/training-material.md
+++ b/support/training-material.md
@@ -10,25 +10,25 @@ Find a selection of trainings and presentations related to solids4foam below.
 
 ## Solid mechanics and fluid-solid interactions using solids4foam-v2.0
 
-[<img src="https://youtu.be/nhgn2mbG--A/maxresdefault.jpg" alt="alt_text" width="60%">](https://youtu.be/nhgn2mbG--A)
+[<img src="https://youtu.be/nhgn2mbG--A/hqdefault.jpg" alt="alt_text" width="60%">](https://youtu.be/nhgn2mbG--A)
 <br>
 [**Slides**](https://www.researchgate.net/publication/372289192_Solid_mechanics_and_fluid-solid_interactions_using_solids4foam-v20): *2023, 18th OpenFOAM Workshop, Genoa, Italy. Speaker: Philip Cardiff*
 
 ## Solid mechanics and fluid-solid interactions using solids4foam 
 
-[<img src="https://youtu.be/UF3BZhL5A4E/maxresdefault.jpg" alt="alt_text" width="60%">](https://youtu.be/UF3BZhL5A4E)
+[<img src="https://youtu.be/UF3BZhL5A4E/hqdefault.jpg" alt="alt_text" width="60%">](https://youtu.be/UF3BZhL5A4E)
 <br>
 [**Slides**](https://www.researchgate.net/publication/362289386_solids4foam_Overview_Demonstration_Cases): *2022, 17th OpenFOAM Workshop, Cambridge, UK. Speaker: Philip Cardiff*
 
 ## Solids4foam training
 
-[<img src="https://youtu.be/uKSQp2dQnGI/maxresdefault.jpg" alt="alt_text" width="60%">](https://youtu.be/uKSQp2dQnGI)
+[<img src="https://youtu.be/uKSQp2dQnGI/hqdefault.jpg" alt="alt_text" width="60%">](https://youtu.be/uKSQp2dQnGI)
 <br>
 [**Slides**](https://www.researchgate.net/publication/373197329_Solid_mechanics_and_fluid-solid_interaction_using_the_solids4foam_toolbox?_sg=Q9hKcWClfLiZAYEAX8HDPeLiEUjMqH8vWQgG4uWiPTfPGdTYFQPsgR_-2mkGFZQFPuUG2lqHtsgdjaLB3CwJn4y7jJ2EKS16cSi7odu8.lZwQLR0F8P8iNwEN6gqtoTX2APNWhoIXpt_qLJO8OlBslEaaBU-G1eiLPQ_UwHvq_Aegm5rX_h8eJh4Rx7vW3g&_tp=eyJjb250ZXh0Ijp7InBhZ2UiOiJfZGlyZWN0In19): *2021, 3rd UCL OpenFOAM Workshop, London, UK. Speaker: Philip Cardiff*
 
 ## Finite volume method for solid mechanics
 
-[<img src="https://youtu.be/Y9Jju-oO_9Q/maxresdefault.jpg" alt="alt_text" width="60%">](https://youtu.be/Y9Jju-oO_9Q)
+[<img src="https://youtu.be/Y9Jju-oO_9Q/hqdefault.jpg" alt="alt_text" width="60%">](https://youtu.be/Y9Jju-oO_9Q)
 <br>
 [**Slides**](https://www.researchgate.net/publication/373197086_The_finite_volume_method_for_solid_mechanics): *2021, 3rd UCL OpenFOAM Workshop, London, UK. Speaker: Philip Cardiff*
 

--- a/support/training-material.md
+++ b/support/training-material.md
@@ -10,25 +10,25 @@ Find a selection of trainings and presentations related to solids4foam below.
 
 ## Solid mechanics and fluid-solid interactions using solids4foam-v2.0
 
-[<img src="https://youtu.be/nhgn2mbG--A/hqdefault.jpg" alt="alt_text" width="60%">](https://youtu.be/nhgn2mbG--A)
+[<img src="https://youtu.be/nhgn2mbG--A/default.jpg" alt="alt_text" width="60%">](https://youtu.be/nhgn2mbG--A)
 <br>
 [**Slides**](https://www.researchgate.net/publication/372289192_Solid_mechanics_and_fluid-solid_interactions_using_solids4foam-v20): *2023, 18th OpenFOAM Workshop, Genoa, Italy. Speaker: Philip Cardiff*
 
 ## Solid mechanics and fluid-solid interactions using solids4foam 
 
-[<img src="https://youtu.be/UF3BZhL5A4E/hqdefault.jpg" alt="alt_text" width="60%">](https://youtu.be/UF3BZhL5A4E)
+[<img src="https://youtu.be/UF3BZhL5A4E/default.jpg" alt="alt_text" width="60%">](https://youtu.be/UF3BZhL5A4E)
 <br>
 [**Slides**](https://www.researchgate.net/publication/362289386_solids4foam_Overview_Demonstration_Cases): *2022, 17th OpenFOAM Workshop, Cambridge, UK. Speaker: Philip Cardiff*
 
 ## Solids4foam training
 
-[<img src="https://youtu.be/uKSQp2dQnGI/hqdefault.jpg" alt="alt_text" width="60%">](https://youtu.be/uKSQp2dQnGI)
+[<img src="https://youtu.be/uKSQp2dQnGI/default.jpg" alt="alt_text" width="60%">](https://youtu.be/uKSQp2dQnGI)
 <br>
 [**Slides**](https://www.researchgate.net/publication/373197329_Solid_mechanics_and_fluid-solid_interaction_using_the_solids4foam_toolbox?_sg=Q9hKcWClfLiZAYEAX8HDPeLiEUjMqH8vWQgG4uWiPTfPGdTYFQPsgR_-2mkGFZQFPuUG2lqHtsgdjaLB3CwJn4y7jJ2EKS16cSi7odu8.lZwQLR0F8P8iNwEN6gqtoTX2APNWhoIXpt_qLJO8OlBslEaaBU-G1eiLPQ_UwHvq_Aegm5rX_h8eJh4Rx7vW3g&_tp=eyJjb250ZXh0Ijp7InBhZ2UiOiJfZGlyZWN0In19): *2021, 3rd UCL OpenFOAM Workshop, London, UK. Speaker: Philip Cardiff*
 
 ## Finite volume method for solid mechanics
 
-[<img src="https://youtu.be/Y9Jju-oO_9Q/hqdefault.jpg" alt="alt_text" width="60%">](https://youtu.be/Y9Jju-oO_9Q)
+[<img src="https://youtu.be/Y9Jju-oO_9Q/default.jpg" alt="alt_text" width="60%">](https://youtu.be/Y9Jju-oO_9Q)
 <br>
 [**Slides**](https://www.researchgate.net/publication/373197086_The_finite_volume_method_for_solid_mechanics): *2021, 3rd UCL OpenFOAM Workshop, London, UK. Speaker: Philip Cardiff*
 

--- a/support/training-material.md
+++ b/support/training-material.md
@@ -10,25 +10,25 @@ Find a selection of trainings and presentations related to solids4foam below.
 
 ## Solid mechanics and fluid-solid interactions using solids4foam-v2.0
 
-[<img src="https://img.youtube.com/vi/7tmuqK58gIA/maxresdefault.jpg" alt="alt_text" width="60%">](https://youtu.be/7tmuqK58gIA)
+[<img src="https://youtu.be/nhgn2mbG--A/maxresdefault.jpg" alt="alt_text" width="60%">](https://youtu.be/nhgn2mbG--A)
 <br>
 [**Slides**](https://www.researchgate.net/publication/372289192_Solid_mechanics_and_fluid-solid_interactions_using_solids4foam-v20): *2023, 18th OpenFOAM Workshop, Genoa, Italy. Speaker: Philip Cardiff*
 
 ## Solid mechanics and fluid-solid interactions using solids4foam 
 
-[<img src="https://img.youtube.com/vi/OxWlBdWnVGo/maxresdefault.jpg" alt="alt_text" width="60%">](https://youtu.be/OxWlBdWnVGo)
+[<img src="https://youtu.be/UF3BZhL5A4E/maxresdefault.jpg" alt="alt_text" width="60%">](https://youtu.be/UF3BZhL5A4E)
 <br>
 [**Slides**](https://www.researchgate.net/publication/362289386_solids4foam_Overview_Demonstration_Cases): *2022, 17th OpenFOAM Workshop, Cambridge, UK. Speaker: Philip Cardiff*
 
 ## Solids4foam training
 
-[<img src="https://img.youtube.com/vi/D3AyykFAW3c/maxresdefault.jpg" alt="alt_text" width="60%">](https://youtu.be/D3AyykFAW3c)
+[<img src="https://youtu.be/uKSQp2dQnGI/maxresdefault.jpg" alt="alt_text" width="60%">](https://youtu.be/uKSQp2dQnGI)
 <br>
 [**Slides**](https://www.researchgate.net/publication/373197329_Solid_mechanics_and_fluid-solid_interaction_using_the_solids4foam_toolbox?_sg=Q9hKcWClfLiZAYEAX8HDPeLiEUjMqH8vWQgG4uWiPTfPGdTYFQPsgR_-2mkGFZQFPuUG2lqHtsgdjaLB3CwJn4y7jJ2EKS16cSi7odu8.lZwQLR0F8P8iNwEN6gqtoTX2APNWhoIXpt_qLJO8OlBslEaaBU-G1eiLPQ_UwHvq_Aegm5rX_h8eJh4Rx7vW3g&_tp=eyJjb250ZXh0Ijp7InBhZ2UiOiJfZGlyZWN0In19): *2021, 3rd UCL OpenFOAM Workshop, London, UK. Speaker: Philip Cardiff*
 
 ## Finite volume method for solid mechanics
 
-[<img src="https://img.youtube.com/vi/sNDWUABn_c4/maxresdefault.jpg" alt="alt_text" width="60%">](https://youtu.be/sNDWUABn_c4)
+[<img src="https://youtu.be/Y9Jju-oO_9Q/maxresdefault.jpg" alt="alt_text" width="60%">](https://youtu.be/Y9Jju-oO_9Q)
 <br>
 [**Slides**](https://www.researchgate.net/publication/373197086_The_finite_volume_method_for_solid_mechanics): *2021, 3rd UCL OpenFOAM Workshop, London, UK. Speaker: Philip Cardiff*
 


### PR DESCRIPTION
Hi @philipcardiff, this is now updated and works for FE4.1. 

Although the change in `dockerfile` (https://github.com/solids4foam/solids4foam/pull/34/commits/39f4d79621821d5f7a9ff7f13dd8da84c1a85615) makes openFoam to compile for `dockeruser`, it still login as `root` instead of `dockeruser`. 

anyway it's ok now and working. 
