### PR TITLE
Mention additional test dependencies

### DIFF
--- a/installation/installFromSource.md
+++ b/installation/installFromSource.md
@@ -70,6 +70,8 @@ Beyond a working version of OpenFOAM or foam-extend, solids4foam does not have a
 | cfmesh | Some tutorials use cfmesh for creating the meshes |
 | gnuplot | Some tutorials use Gnuplot to generate graphs after running the solver |
 
+Note that, for running the tests, the OpenFOAM or foam-extend tutorials are also required.
+
 #### Eigen
 
 Before building solids4foam, the `EIGEN_DIR` environment variable can be set to the local Eigen installation location. If `EIGEN_DIR` is not set, then solids4foam will download a local copy of Eigen.

--- a/installation/installFromSource.md
+++ b/installation/installFromSource.md
@@ -71,6 +71,7 @@ Beyond a working version of OpenFOAM or foam-extend, solids4foam does not have a
 | gnuplot | Some tutorials use Gnuplot to generate graphs after running the solver |
 
 Note that, for running the tests, the OpenFOAM or foam-extend tutorials are also required.
+If preCICE is installed, this will enable additional tests.
 
 #### Eigen
 


### PR DESCRIPTION
When running the tests, I got multiple times the message:

```
No OpenFOAM tutorials? : /usr/lib/openfoam/openfoam2312/tutorials
```

I have multiple OpenFOAM versions installed on my system, but not the tutorials for all the versions. This PR adds a hint that the tutorials package is also required for the tests. I am not sure to what extent this is required, though.

Similarly, I had some tests failing because I had preCICE installed, but a different version than expected (see https://github.com/solids4foam/solids4foam/pull/146). This PR also mentions preCICE as an optional dependency for the tests.

This is in the context of my review for the JOSS publication (https://github.com/openjournals/joss-reviews/issues/7407).