### PR TITLE
Fix typo in Homebrew install command for styro

### DIFF
--- a/installation/installWithStyro.md
+++ b/installation/installWithStyro.md
@@ -68,7 +68,7 @@ pip install styro
 Using Homebrew (recommended):
 
 ```bash
-brew install gerlero/tap/styro
+brew install gerlero/openfoam/styro
 ```
 
 ---


### PR DESCRIPTION
Just caught the typo in this doc page!