### PR TITLE
Adding beamfoam-tutorial video links from youtube + minor edits to remove shell prompt indicator

### DIFF
--- a/sister-repositories/beamFoam/documentation/README.md
+++ b/sister-repositories/beamFoam/documentation/README.md
@@ -102,7 +102,6 @@ The primary unknowns are:
 Boundary conditions in `0/W` and `0/Theta` apply end constraints, forces and
 moments. Distributed loads may be supplied through fields such as `q`, while
 time-dependent end loads are commonly defined by data files under `constant/`.
-Additional momentum contributions include Morison drag and ground contact.
 
 Static and dynamic behavior is selected through the case dictionaries. Dynamic
 cases can use OpenFOAM time-discretisation schemes such as Euler or Newmark,
@@ -114,8 +113,8 @@ The point displacement field `pointW` is intended for visualising the deformed
 beam in ParaView:
 
 ```bash
-> touch case.foam
-> paraview case.foam
+touch case.foam
+paraview case.foam
 ```
 
 Apply the **Warp By Vector** filter using `pointW`. Many tutorials also provide

--- a/sister-repositories/beamFoam/installation/README.md
+++ b/sister-repositories/beamFoam/installation/README.md
@@ -19,14 +19,14 @@ principal tested version described in the beamFoam paper.
 Source the OpenFOAM environment before installing beamFoam. For example:
 
 ```bash
-> source /path/to/OpenFOAM-v2306/etc/bashrc
+source /path/to/OpenFOAM-v2306/etc/bashrc
 ```
 
 Confirm that the environment is active:
 
 ```bash
-> echo $WM_PROJECT_VERSION
-> which wmake
+echo $WM_PROJECT_VERSION
+which wmake
 ```
 
 ## Download and Build
@@ -34,12 +34,12 @@ Confirm that the environment is active:
 A convenient location is beside the OpenFOAM run directory:
 
 ```bash
-> mkdir -p $FOAM_RUN
-> cd $FOAM_RUN/..
-> git clone https://github.com/solids4foam/beamFoam.git
-> cd beamFoam
-> ./Allwclean
-> ./Allwmake
+mkdir -p $FOAM_RUN
+cd $FOAM_RUN/..
+git clone https://github.com/solids4foam/beamFoam.git
+cd beamFoam
+./Allwclean
+./Allwmake
 ```
 
 The top-level build script builds the Eigen dependency, beam model library,
@@ -51,17 +51,17 @@ errors are found in the generated build logs.
 After a successful build, verify that the main applications are available:
 
 ```bash
-> which beamFoam
-> which createBeamMesh
-> which setInitialPositionBeam
+which beamFoam
+which createBeamMesh
+which setInitialPositionBeam
 ```
 
 Run one of the supplied cases to verify the complete workflow:
 
 ```bash
-> cd tutorials/cantilever
-> ./Allclean
-> ./Allrun
+cd tutorials/cantilever
+./Allclean
+./Allrun
 ```
 
 See the [tutorial guide](../tutorials/README.md) for the featured validation
@@ -72,9 +72,9 @@ cases and post-processing instructions.
 To remove generated build products and rebuild:
 
 ```bash
-> cd $FOAM_RUN/../beamFoam
-> ./Allwclean
-> ./Allwmake
+cd $FOAM_RUN/../beamFoam
+./Allwclean
+./Allwmake
 ```
 
 When changing OpenFOAM versions, clean beamFoam before rebuilding it in the new

--- a/sister-repositories/beamFoam/tutorials/README.md
+++ b/sister-repositories/beamFoam/tutorials/README.md
@@ -59,7 +59,7 @@ physical setup, dictionaries, execution, post-processing and expected results.
 
 The repository also includes:
 
-- [`cantilever`](cantilever/README.md):
+- [`cantilever`](cantilever/):
   pure bending under a concentrated end moment
 - [`largeDeflectionCantilever`](https://github.com/solids4foam/beamFoam/tree/main/tutorials/largeDeflectionCantilever):
   a rectangular cantilever under self-weight

--- a/sister-repositories/beamFoam/tutorials/README.md
+++ b/sister-repositories/beamFoam/tutorials/README.md
@@ -14,9 +14,9 @@ Source OpenFOAM and ensure beamFoam is compiled before running a tutorial. A
 typical workflow is:
 
 ```bash
-> cd $FOAM_RUN/../beamFoam/tutorials/3dDynamicCantilever
-> ./Allclean
-> ./Allrun
+cd $FOAM_RUN/../beamFoam/tutorials/3dDynamicCantilever
+./Allclean
+./Allrun
 ```
 
 The scripts generally:
@@ -31,7 +31,7 @@ Clean a case before repeating it or after changing its mesh, time step or time
 scheme:
 
 ```bash
-> ./Allclean
+./Allclean
 ```
 
 ## Post-Processing
@@ -39,8 +39,8 @@ scheme:
 Open the generated case in ParaView:
 
 ```bash
-> touch case.foam
-> paraview case.foam
+touch case.foam
+paraview case.foam
 ```
 
 Apply **Warp By Vector** using `pointW` to visualise the deformed beam. Function

--- a/sister-repositories/beamFoam/tutorials/README.md
+++ b/sister-repositories/beamFoam/tutorials/README.md
@@ -59,7 +59,7 @@ physical setup, dictionaries, execution, post-processing and expected results.
 
 The repository also includes:
 
-- [`cantilever`](https://github.com/solids4foam/beamFoam/tree/main/tutorials/cantilever):
+- [`cantilever`](cantilever/README.md):
   pure bending under a concentrated end moment
 - [`largeDeflectionCantilever`](https://github.com/solids4foam/beamFoam/tree/main/tutorials/largeDeflectionCantilever):
   a rectangular cantilever under self-weight

--- a/sister-repositories/beamFoam/tutorials/cantilever/README.md
+++ b/sister-repositories/beamFoam/tutorials/cantilever/README.md
@@ -1,0 +1,1 @@
+../../../../imported/beamFoam/tutorials/cantilever/README.md


### PR DESCRIPTION
Two changes here:

1. Remove shell prompt indicator from beamFoam documentation codes. 50913a80f7d9ffab99dc6cdbcb9ac12c2ee67c35
2. Update the symbolic links of beamFoam tutorial README to embed video links to beamFoam webpage and update the beamFoam submodule to new commit. 49d252adb101fc979e2748edc45dcc01355b9411

FYI, @philipcardiff. 